### PR TITLE
If there is no space in the address, try splitting by number.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 DS_Store
 composer.lock
+.idea

--- a/src/Shared/Helpers/AddressParser.php
+++ b/src/Shared/Helpers/AddressParser.php
@@ -17,7 +17,15 @@ class AddressParser
     public static function parseFirstLine($firstLine)
     {
         $parts = preg_split('/\\s/', $firstLine, null, PREG_SPLIT_NO_EMPTY);
-        $street = array_shift($parts);
+
+        if (count($parts) < 2) {
+            preg_match('/\d+[^\d]+/', $firstLine, $house);
+
+            $parts[0] = trim(strstr($firstLine, $house[0], true));
+            $parts[1] = trim($house[0]);
+        }
+
+        $street = str_replace(',', '', array_shift($parts));
         $houseNumber = null;
         if (static::couldBePartOfHouseNumber(end($parts))) {
             $houseNumber = array_pop($parts);

--- a/src/Shared/Helpers/AddressParser.php
+++ b/src/Shared/Helpers/AddressParser.php
@@ -16,16 +16,8 @@ class AddressParser
      */
     public static function parseFirstLine($firstLine)
     {
-        $parts = preg_split('/\\s/', $firstLine, null, PREG_SPLIT_NO_EMPTY);
-
-        if (count($parts) < 2) {
-            preg_match('/\d+[^\d]+/', $firstLine, $house);
-
-            $parts[0] = trim(strstr($firstLine, $house[0], true));
-            $parts[1] = trim($house[0]);
-        }
-
-        $street = str_replace(',', '', array_shift($parts));
+        $parts = static::splitFirstLine($firstLine);
+        $street = array_shift($parts);
         $houseNumber = null;
         if (static::couldBePartOfHouseNumber(end($parts))) {
             $houseNumber = array_pop($parts);
@@ -47,7 +39,31 @@ class AddressParser
         while ($parts) {
             $street .= ' '.array_shift($parts);
         }
+        $street = trim($street);
+        if ($houseNumber) {
+            $houseNumber = trim($houseNumber);
+        }
         return [$street, $houseNumber];
+    }
+
+    /**
+     * Tries to split first line into parts
+     *
+     * @param string $firstLine
+     * @return array
+     */
+    protected static function splitFirstLine($firstLine)
+    {
+        $parts = preg_split('/\\s/', $firstLine, null, PREG_SPLIT_NO_EMPTY);
+        if (count($parts) > 1) {
+            return $parts;
+        }
+        $parts = explode(',', $firstLine);
+        if (count($parts) > 1) {
+            return $parts;
+        }
+
+        return preg_split('/(\\d+\\D*)/', $firstLine, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
     }
 
     /**

--- a/tests/Shared/Helpers/AddressParserTest.php
+++ b/tests/Shared/Helpers/AddressParserTest.php
@@ -27,5 +27,11 @@ class AddressParserTest extends PHPUnit_Framework_TestCase
         $this->assertSame(['Meierskamp','31b'], AddressParser::parseFirstLine('Meierskamp31b'));
         $this->assertSame(['Meierskamp','31b'], AddressParser::parseFirstLine('Meierskamp,31b'));
         $this->assertSame(['Meierskamp','315XI'], AddressParser::parseFirstLine('Meierskamp315XI'));
+
+        $this->assertSame(['Hauptstraße', '12'], AddressParser::parseFirstLine('Hauptstraße,12'));
+        $this->assertSame(['Hauptstraße', ''], AddressParser::parseFirstLine('Hauptstraße,'));
+        $this->assertSame(['Hauptstraße', null], AddressParser::parseFirstLine('Hauptstraße'));
+        $this->assertSame(['Hauptstraße', '12'], AddressParser::parseFirstLine('Hauptstraße,,,12'));
+        $this->assertSame(['Hauptstraße', '12'], AddressParser::parseFirstLine('Hauptstraße12'));
     }
 }

--- a/tests/Shared/Helpers/AddressParserTest.php
+++ b/tests/Shared/Helpers/AddressParserTest.php
@@ -22,5 +22,10 @@ class AddressParserTest extends PHPUnit_Framework_TestCase
         $this->assertSame(['Square of the Day of the 1st Vi.', 'VI. - III.'], AddressParser::parseFirstLine('Square of the Day of the 1st Vi. VI. - III. '));
         $this->assertSame(['Square of the Day of the', '1st VI. VI. - III.'], AddressParser::parseFirstLine('Square of the Day of the 1st VI. VI. - III. '));
         $this->assertSame(['Square of the Day of the', '1st vi. vi. - iii.'], AddressParser::parseFirstLine('Square of the Day of the 1st vi. vi. - iii. '));
+
+        $this->assertSame(['Meierskamp','31b'], AddressParser::parseFirstLine('Meierskamp 31b'));
+        $this->assertSame(['Meierskamp','31b'], AddressParser::parseFirstLine('Meierskamp31b'));
+        $this->assertSame(['Meierskamp','31b'], AddressParser::parseFirstLine('Meierskamp,31b'));
+        $this->assertSame(['Meierskamp','315XI'], AddressParser::parseFirstLine('Meierskamp315XI'));
     }
 }


### PR DESCRIPTION
We had some problems with addresses such as "Meierskamp,31b" where there is no space. I added logic that tries splitting the house number by the first number it finds if it was unable to do so using a space.
